### PR TITLE
feat!: reimplementation

### DIFF
--- a/audio_finder/main.py
+++ b/audio_finder/main.py
@@ -31,17 +31,20 @@ class ArchiveSearch():
 
 
 def parse_size(size):
-    # parse size in bytes, or MB, or GB.  Return size in bytes.
+    '''
+    Parse size in bytes, or MB, or GB.  Return size in bytes.
+    '''
     size = size.upper()
     if size[-2:] == 'MB':
         return int(size[:-2]) * 1024 * 1024
     elif size[-2:] == 'GB':
         return int(size[:-2]) * 1024 * 1024 * 1024
-    else:
-        return int(size)
+    return int(size)
 
 def search_pipeline(title, min_size):
-     # search for items
+    '''
+    Given `title` and `min_size`, search Internet Archive for audio matching the title.
+    '''
     search = ArchiveSearch(title=title)
     # IF control-c is pressed, exit the loop gracefully
     try:
@@ -56,7 +59,6 @@ def search_pipeline(title, min_size):
                 # We would typically expect that the search 'item_size:[1000 TO null]' to work, but it does not.
                 if n.item_size < min_size:
                     continue
-                #csv.append([g.metadata['identifier'],g.metadata['title'],(f"{(size / 1024 / 1024):.2f} MB")])
                 print(n.title)
                 print("\t",f"http://archive.org/details/{n.metadata['identifier']}")
                 print("\t",n.metadata['mediatype'])

--- a/audio_finder/main.py
+++ b/audio_finder/main.py
@@ -19,10 +19,11 @@ class ArchiveItem():
         self.item.download(dry_run=True)
 
 class ArchiveSearch():
-    def __init__(self, title):
+    def __init__(self, title, subject=None):
         self.title = f'title:"{title}"'
+        self.subject = f'subject:"{subject}"' if subject else None
         media_type = 'mediatype:audio'
-        search_terms = filter(lambda x: x is not None, [media_type,self.title])
+        search_terms = filter(lambda x: x is not None, [media_type,self.title,self.subject])
         self.query = ' AND '.join(search_terms)
     def search_items(self):
         # search_items yields, so we want to yield from it rather than return
@@ -40,11 +41,11 @@ def parse_size(size):
         return int(size[:-2]) * 1024 * 1024 * 1024
     return int(size)
 
-def search_pipeline(title, min_size):
+def search_pipeline(title, min_size, subject):
     '''
     Given `title` and `min_size`, search Internet Archive for audio matching the title.
     '''
-    search = ArchiveSearch(title=title)
+    search = ArchiveSearch(title=title,subject=subject)
     # IF control-c is pressed, exit the loop gracefully
     try:
         print("Searching...")
@@ -74,12 +75,13 @@ def search_pipeline(title, min_size):
 
 def main():
     argparser = argparse.ArgumentParser()
-    argparser.add_argument('title', help='Title to search for')
+    argparser.add_argument('title', help='Title to search for.  Always required.')
+    argparser.add_argument('--subject', type=str, default=None, help='Optional subject to search for.')
     argparser.add_argument('--min_size', '--min-size', type=str, default="0MB", help='Minimum size of item to search for.  Supports expressions in MB or GB, like 1MB or 1GB')
     args = argparser.parse_args()
     size = parse_size(args.min_size)
     
-    search_pipeline(title=args.title, min_size=size)
+    search_pipeline(title=args.title, min_size=size, subject=args.subject)
 
 if __name__=='__main__':
     sys.exit(main())

--- a/audio_finder/main.py
+++ b/audio_finder/main.py
@@ -1,6 +1,5 @@
 import internetarchive as ia
 import argparse
-import time
 import sys
 
 session = ia.get_session()

--- a/audio_finder/main.py
+++ b/audio_finder/main.py
@@ -77,7 +77,7 @@ def main():
     argparser = argparse.ArgumentParser()
     argparser.add_argument('title', help='Title to search for.  Always required.')
     argparser.add_argument('--subject', type=str, default=None, help='Optional subject to search for.')
-    argparser.add_argument('--min_size', '--min-size', type=str, default="0MB", help='Minimum size of item to search for.  Supports expressions in MB or GB, like 1MB or 1GB')
+    argparser.add_argument('--min_size', '--min-size', type=str, default="0MB", help='Minimum size of item to search for.  Supports expressions in MB or GB, like 1MB or 1GB.')
     args = argparser.parse_args()
     size = parse_size(args.min_size)
     

--- a/audio_finder/main.py
+++ b/audio_finder/main.py
@@ -20,11 +20,10 @@ class ArchiveItem():
         self.item.download(dry_run=True)
 
 class ArchiveSearch():
-    def __init__(self, subject, title_match=False):
-        self.subject = f'subject:"{subject}"'
-        self.title_match = f'title:"{subject}"' if title_match is True else None
+    def __init__(self, title):
+        self.title = f'title:"{title}"'
         media_type = 'mediatype:audio'
-        search_terms = filter(lambda x: x is not None, [media_type,self.subject,self.title_match])
+        search_terms = filter(lambda x: x is not None, [media_type,self.title])
         self.query = ' AND '.join(search_terms)
     def search_items(self):
         # search_items yields, so we want to yield from it rather than return
@@ -41,9 +40,9 @@ def parse_size(size):
     else:
         return int(size)
 
-def search_pipeline(subject, min_size,title_match):
+def search_pipeline(title, min_size):
      # search for items
-    search = ArchiveSearch(subject,title_match=title_match)
+    search = ArchiveSearch(title=title)
     # IF control-c is pressed, exit the loop gracefully
     try:
         print("Searching...")
@@ -74,13 +73,12 @@ def search_pipeline(subject, min_size,title_match):
 
 def main():
     argparser = argparse.ArgumentParser()
-    argparser.add_argument('subject', help='subject to search for')
+    argparser.add_argument('title', help='Title to search for')
     argparser.add_argument('--min_size', '--min-size', type=str, default="0MB", help='Minimum size of item to search for.  Supports expressions in MB or GB, like 1MB or 1GB')
-    argparser.add_argument('--title_match', '--title-match', action='store_true', default=False, help='Use provided subject to search subject AND title.')
     args = argparser.parse_args()
     size = parse_size(args.min_size)
     
-    search_pipeline(subject=args.subject, min_size=size, title_match=args.title_match)
+    search_pipeline(title=args.title, min_size=size)
 
 if __name__=='__main__':
     sys.exit(main())

--- a/audio_finder/test_main.py
+++ b/audio_finder/test_main.py
@@ -5,7 +5,7 @@ def test_parse_size():
     assert parse_size("1MB") == 1048576
 
 def test_archive_search():
-    search = ArchiveSearch("Kool and the gang")
-    assert search.query == 'mediatype:audio AND subject:"Kool and the gang"'
-    search = ArchiveSearch(subject="Parliment Funkadelic", title_match=True)
-    assert search.query == 'mediatype:audio AND subject:"Parliment Funkadelic" AND title:"Parliment Funkadelic"'
+    search = ArchiveSearch(title="Kool and the gang")
+    assert search.query == 'mediatype:audio AND title:"Kool and the gang"'
+    search = ArchiveSearch(title="Parliment Funkadelic")
+    assert search.query == 'mediatype:audio AND title:"Parliment Funkadelic"'

--- a/audio_finder/test_main.py
+++ b/audio_finder/test_main.py
@@ -9,3 +9,5 @@ def test_archive_search():
     assert search.query == 'mediatype:audio AND title:"Kool and the gang"'
     search = ArchiveSearch(title="Parliment Funkadelic")
     assert search.query == 'mediatype:audio AND title:"Parliment Funkadelic"'
+    search = ArchiveSearch(title="George Clinton",subject="Funk music")
+    assert search.query == 'mediatype:audio AND title:"George Clinton" AND subject:"Funk music"'


### PR DESCRIPTION
When originally implemented, this was using a broad search not constrained to `subject:` as should have been done originally.  Because of that, by adopting this in #7 , this started to expose a bug.  This is now more correctly implemented as `title:` as the intended feature.  `subject` was made available again, as a separate parameter.  

As a result, this is considered a non-backwards compatible change.